### PR TITLE
Fix duplicate password assignment in updateUser

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -78,7 +78,6 @@ exports.updateUser = async (req, res) => {
         const { email, password } = req.body;
         if (email) user.email = email;
         if (password) user.password = password; // Le hash sera fait automatiquement via le middleware Mongoose
-        if (password) user.password = password;
 
         const updatedUser = await user.save();
         res.status(200).json({ message: 'Utilisateur mis à jour.', user: updatedUser });


### PR DESCRIPTION
## Summary
- remove redundant password assignment in `updateUser`

## Testing
- `npm test` *(fails: `MONGO_URI is not defined in your environment variables`)*

------
https://chatgpt.com/codex/tasks/task_e_685a43c3958483318c04db196dc9c6ff