### PR TITLE
Add login route tests

### DIFF
--- a/backend/tests/login.test.js
+++ b/backend/tests/login.test.js
@@ -1,0 +1,38 @@
+const request = require('supertest');
+const app = require('../app');
+const User = require('../models/user');
+const bcrypt = require('bcrypt');
+
+process.env.JWT_SECRET = 'testsecret';
+
+jest.mock('../models/user');
+jest.mock('bcrypt');
+
+describe('POST /api/users/login', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return token when credentials are valid', async () => {
+    User.findOne.mockResolvedValue({ _id: '123', password: 'hashed' });
+    bcrypt.compare.mockResolvedValue(true);
+
+    const res = await request(app)
+      .post('/api/users/login')
+      .send({ email: 'login@example.com', password: 'Password123!' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('should return 400 when password is wrong', async () => {
+    User.findOne.mockResolvedValue({ _id: '123', password: 'hashed' });
+    bcrypt.compare.mockResolvedValue(false);
+
+    const res = await request(app)
+      .post('/api/users/login')
+      .send({ email: 'login@example.com', password: 'WrongPassword' });
+
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for POST `/api/users/login`

## Testing
- `npm test` *(fails: MONGO_URI is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685a4be24cf48331af95ea17634ab83f