### PR TITLE
Fix updateUser and login/register messages

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -78,7 +78,6 @@ exports.updateUser = async (req, res) => {
         const { email, password } = req.body;
         if (email) user.email = email;
         if (password) user.password = password; // Le hash sera fait automatiquement via le middleware Mongoose
-        if (password) user.password = password;
 
         const updatedUser = await user.save();
         res.status(200).json({ message: 'Utilisateur mis à jour.', user: updatedUser });

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -36,7 +36,7 @@ const loginUser = async () => {
       email: email.value,
       password: password.value,
     });
-    success.value = 'Enregistrement réussi. Vous pouvez maintenant vous connecter.';
+    success.value = 'Connexion réussie. Redirection en cours...';
     error.value = '';
     setTimeout(() => {
       router.push('/objects');

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -33,7 +33,7 @@ const registerUser = async () => {
       email: email.value,
       password: password.value,
     });
-    success.value = 'Inscription réussit ! Vous allez être rediriger vers la page de login.';
+    success.value = "Inscription réussie ! Redirection vers la page de login...";
     error.value = '';
     email.value = '';
     password.value = '';


### PR DESCRIPTION
## Summary
- remove duplicate password assignment in `updateUser`
- fix login success message
- fix register success message

## Testing
- `npm test` *(fails: MONGO_URI is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68597485dfbc83318d35d554bfb03257